### PR TITLE
Add .phpactor.json to gitignore and improve LSP references

### DIFF
--- a/git/dot-gitignore
+++ b/git/dot-gitignore
@@ -17,3 +17,5 @@ nvim/.config/nvim/spell
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
+
+.phpactor.json

--- a/nvim/.config/nvim/after/plugin/lsp.lua
+++ b/nvim/.config/nvim/after/plugin/lsp.lua
@@ -47,6 +47,7 @@ vim.api.nvim_create_autocmd('LspAttach', {
     local opts = {buffer = event.buf}
 
     vim.keymap.set('n', 'gd', function() vim.lsp.buf.definition() end, opts)
+    vim.keymap.set('n', 'gr', function() vim.lsp.buf.references() end, opts)
     vim.keymap.set('n', 'K', function() vim.lsp.buf.hover() end, opts)
     vim.keymap.set('n', '<leader>vws', function() vim.lsp.buf.workspace_symbol() end, opts)
     vim.keymap.set('n', '<leader>vd', function() vim.diagnostic.open_float() end, opts)

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -156,3 +156,8 @@ alias sail='sh $([ -f sail ] && echo sail || echo vendor/bin/sail)'
 
 # Fig post block. Keep at the bottom of this file.
 [[ -f "$HOME/.fig/shell/zshrc.post.zsh" ]] && builtin source "$HOME/.fig/shell/zshrc.post.zsh"
+
+. "$HOME/.atuin/bin/env"
+
+eval "$(atuin init zsh)"
+


### PR DESCRIPTION
## Summary

- Add a keybinding for `'gr'` in normal mode to quickly access LSP references
- Integrate Atuin into `.zshrc` config
- Add `.phpactor.json` to the gitignore file