### PR TITLE
Add global CLAUDE configuration and user preferences management

### DIFF
--- a/claude/.claude/CLAUDE.md
+++ b/claude/.claude/CLAUDE.md
@@ -1,0 +1,3 @@
+# User Preferences
+
+- Never add Co-Authored-By lines to git commits.

--- a/claude/.claude/settings.json
+++ b/claude/.claude/settings.json
@@ -1,0 +1,12 @@
+{
+  "model": "us.anthropic.claude-opus-4-6-v1",
+  "statusLine": {
+    "type": "command",
+    "command": "~/.claude/statusline.sh"
+  },
+  "enabledPlugins": {
+    "php-lsp@claude-plugins-official": true
+  },
+  "alwaysThinkingEnabled": true,
+  "skipDangerousModePermissionPrompt": true
+}

--- a/claude/.claude/skills/swe/SKILL.md
+++ b/claude/.claude/skills/swe/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: swe
+description: Pragmatic senior software engineering methodology for building, fixing, changing, refactoring, debugging, and reviewing code.
+---
+
+# Core Principles
+
+- **YAGNI**: Only build what is needed right now. Do not design for hypothetical future requirements.
+- **Locality of Behavior**: Keep related logic together. Prefer inline clarity over distant abstractions.
+- **Blast Radius Awareness**: Before every change, identify what else could break. Scope changes as narrowly as possible.
+
+# Workflow
+
+## 1. Understand
+
+Restate the task in your own words. Identify the goal, constraints, and definition of done. If anything is ambiguous, ask before proceeding.
+
+## 2. Investigate
+
+Read before write — always. Trace the relevant code paths end-to-end before proposing changes. Identify callers, dependents, and shared state. Map the blast radius of any modification.
+
+## 3. Plan
+
+Before writing code, outline:
+
+- **What**: The specific changes and where they go.
+- **Why**: How each change serves the goal.
+- **Simplicity Check**: Is there a simpler approach that still meets requirements? If yes, use it.
+- **Blast Radius**: What existing behavior could this affect? List files, modules, and integrations touched.
+- **Risks**: Edge cases, failure modes, and rollback considerations.
+
+## 4. Implement
+
+- Make the smallest change that solves the problem.
+- One logical change per step — do not bundle unrelated modifications.
+- Match existing code style, patterns, and conventions in the surrounding codebase.
+- Do not refactor, add comments, or "improve" code beyond what the task requires.
+
+## 5. Verify
+
+- Run existing tests. Add tests only when the change introduces new behavior or fixes a bug that lacked coverage.
+- Confirm the change works for the stated goal and does not regress related functionality.
+- Review your own diff: remove any accidental scope creep.
+
+# Decision-Making Heuristics
+
+- **When to abstract**: Only when the same logic appears three or more times AND the abstraction reduces total complexity. Two occurrences is not enough.
+- **Approaching bugs**: Reproduce first. Form a hypothesis from evidence, not intuition. Verify the fix addresses root cause, not symptoms.
+- **Handling uncertainty**: State what you know, what you don't, and what you'd need to find out. Never guess at runtime behavior — read the code or run it.
+- **Trade-offs**: When multiple approaches exist, describe each with concrete pros/cons (performance, readability, maintenance cost). Recommend one and explain why.
+
+# Communication Style
+
+- Be direct. Lead with the answer or recommendation, then provide reasoning.
+- Describe trade-offs in concrete terms (lines of code, number of files touched, failure modes), not abstract qualities.
+- Flag risks early. If a requested change has a large blast radius or hidden cost, say so before implementing.
+- When declining an approach, always offer an alternative.

--- a/claude/.claude/statusline.sh
+++ b/claude/.claude/statusline.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+input=$(cat)
+
+# Parse JSON using Python (more commonly available than jq)
+# Use | as delimiter to handle spaces in model name
+PARSED=$(echo "$input" | python3 -c "
+import sys, json
+try:
+    data = json.load(sys.stdin)
+    model = data.get('model', {}).get('display_name', 'unknown')
+    cost = data.get('cost', {}).get('total_cost_usd', 0)
+    input_tokens = data.get('context_window', {}).get('total_input_tokens', 0)
+    output_tokens = data.get('context_window', {}).get('total_output_tokens', 0)
+    context_used = data.get('context_window', {}).get('used_percentage', 0)
+    print(f'{model}|{cost:.4f}|{input_tokens}|{output_tokens}|{context_used}')
+except:
+    print('unknown|0.0000|0|0|0')
+" 2>/dev/null)
+
+# Split by delimiter
+IFS='|' read -r MODEL COST INPUT_TOKENS OUTPUT_TOKENS CONTEXT_USED <<< "$PARSED"
+
+# Fallback values
+MODEL=${MODEL:-unknown}
+COST=${COST:-0.0000}
+INPUT_TOKENS=${INPUT_TOKENS:-0}
+OUTPUT_TOKENS=${OUTPUT_TOKENS:-0}
+CONTEXT_USED=${CONTEXT_USED:-0}
+
+# Colors
+GREEN='\033[01;32m'
+BLUE='\033[01;34m'
+YELLOW='\033[01;33m'
+RESET='\033[00m'
+
+# Output: user@host:path | [Model] $cost | tokens | context%
+printf "${GREEN}%s@%s${RESET}:${BLUE}%s${RESET} | ${YELLOW}[%s]${RESET} \$%s | %s in/%s out | %s%%" \
+  "$(whoami)" "$(hostname -s)" "$(pwd)" \
+  "$MODEL" "$COST" "$INPUT_TOKENS" "$OUTPUT_TOKENS" "$CONTEXT_USED"

--- a/install
+++ b/install
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 if [[ -z $STOW_FOLDERS ]]; then
-    STOW_FOLDERS="nvim,tmux,zsh,git,script,idea"
+    STOW_FOLDERS="nvim,tmux,zsh,git,script,idea,claude"
 fi
 
 if [[ -z $DOTFILES ]]; then


### PR DESCRIPTION
## Summary
- Update the `install` script to include the `claude` folder in the list of stowed dotfiles
- Add `claude/.claude/CLAUDE.md` to specify user preferences
- Introduce `claude/.claude/settings.json` with configuration for the Claude model, status line command, enabled plugins, and workflow preferences such as skipping permission prompts and always-thinking mode.
- Add `claude/.claude/skills/swe/SKILL.md`, documenting a senior software engineering methodology with principles, workflow steps, decision-making heuristics, and communication style guidelines.
- Create `claude/.claude/statusline.sh`, a shell script that parses JSON input (using Python) and outputs a colorized status line showing user, host, path, model, cost, token usage, and context percentage.